### PR TITLE
Tweaks: ABC validation and UI

### DIFF
--- a/folk_rnn_site/composer/__init__.py
+++ b/folk_rnn_site/composer/__init__.py
@@ -1,5 +1,7 @@
 import os
 
+FOLKRNN_MAX_SEED = 1000000
+
 # conforming abc
 
 ABC2ABC_PATH = '/usr/bin/abc2abc'

--- a/folk_rnn_site/composer/forms.py
+++ b/folk_rnn_site/composer/forms.py
@@ -10,15 +10,14 @@ class ChoiceFieldNoValidation(forms.ChoiceField):
         pass
 
 class ComposeForm(forms.Form):
-    model = forms.ChoiceField(label='RNN Model:', choices=rnn_choices())
-    temp = forms.DecimalField(label='RNN Temperature:', min_value=0.01, max_value=10, decimal_places=2, initial=1)
-    seed = forms.IntegerField(label='RNN Seed:', min_value=0, max_value=2**15, initial=lambda : randint(0, 2**15))
-    meter = ChoiceFieldNoValidation(label='Meter:', choices=())
-    key = ChoiceFieldNoValidation(label='Key:', choices=())
-    start_abc = forms.CharField(label='Prime tokens:', 
-                           widget=forms.Textarea(),
-                           error_messages={'invalid': 'Invalid ABC notation as per the RNN model'},
-                           required=False)
+    model = forms.ChoiceField(choices=rnn_choices())
+    temp = forms.DecimalField(min_value=0.01, max_value=10, decimal_places=2, initial=1)
+    seed = forms.IntegerField(min_value=0, max_value=2**15, initial=lambda : randint(0, 2**15))
+    meter = ChoiceFieldNoValidation(choices=())
+    key = ChoiceFieldNoValidation(choices=())
+    start_abc = forms.CharField(widget=forms.Textarea(),
+                               error_messages={'invalid': 'Invalid ABC notation as per the RNN model'},
+                               required=False)
 
     # Validate whole form as validation (might) depend on particular model
     def clean(self):

--- a/folk_rnn_site/composer/forms.py
+++ b/folk_rnn_site/composer/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from random import randint
 
+from composer import FOLKRNN_MAX_SEED
 from composer.rnn_models import choices as rnn_choices
 from composer.rnn_models import validate_tokens, validate_meter, validate_key
 
@@ -12,7 +13,7 @@ class ChoiceFieldNoValidation(forms.ChoiceField):
 class ComposeForm(forms.Form):
     model = forms.ChoiceField(choices=rnn_choices())
     temp = forms.DecimalField(min_value=0.01, max_value=10, decimal_places=2, initial=1)
-    seed = forms.IntegerField(min_value=0, max_value=2**15, initial=lambda : randint(0, 2**15))
+    seed = forms.IntegerField(min_value=0, max_value=FOLKRNN_MAX_SEED, initial=lambda : randint(0, FOLKRNN_MAX_SEED))
     meter = ChoiceFieldNoValidation(choices=())
     key = ChoiceFieldNoValidation(choices=())
     start_abc = forms.CharField(widget=forms.Textarea(),

--- a/folk_rnn_site/composer/rnn_models.py
+++ b/folk_rnn_site/composer/rnn_models.py
@@ -27,7 +27,7 @@ def models():
                 job_spec = pickle.load(f)
             model = {}
             model['tokens'] = set(job_spec['token2idx'].keys())
-            model['display_name'] = filename.replace('_', ' ').replace('.pickle', '')
+            model['display_name'] = job_spec['name']
             model['header_m_tokens'] = sorted({x for x in model['tokens'] if x.startswith('M:')}, key=lambda x: int(x[2:].split('/')[0]))
             model['header_k_tokens'] = sorted({x for x in model['tokens'] if x.startswith('K:')})
             models[filename] = model

--- a/folk_rnn_site/composer/static/folk_rnn_client.js
+++ b/folk_rnn_site/composer/static/folk_rnn_client.js
@@ -83,7 +83,11 @@ folkrnn.tuneManager = {
             warnings_id:"warnings",
             midi_options: {
                 generateDownload: true,
-                downloadLabel:"Download MIDI"
+                downloadLabel:"Download MIDI",
+                inlineControls: {
+                    tempo: true,
+                },
+                //selectionToggle: true, // not yet implemented according to https://github.com/paulrosen/abcjs/blob/master/docs/api.md
             },
             render_options: {
                 paddingleft:0,

--- a/folk_rnn_site/composer/static/folk_rnn_client.js
+++ b/folk_rnn_site/composer/static/folk_rnn_client.js
@@ -25,7 +25,7 @@ folkrnn.initialise = function() {
     
     folkrnn.composeButton.addEventListener("click", folkrnn.generateRequest);
     
-    folkrnn.div_tune.setAttribute('style', 'display: none');
+    folkrnn.div_tune.setAttribute('hidden', '');
     
     folkrnn.websocketConnect();
 };
@@ -35,7 +35,7 @@ folkrnn.tuneManager = {
     'addTune': function (tune_id) {
         "use strict";
         // Hide about div, now there is a tune
-        folkrnn.div_about.setAttribute('style', 'display: none');
+        folkrnn.div_about.setAttribute('hidden', '');
         
         // Add tune to manager
         const div_tune_new = folkrnn.div_tune.cloneNode(true);
@@ -59,7 +59,7 @@ folkrnn.tuneManager = {
         
         // Place on page
         folkrnn.div_tune.parentNode.insertBefore(div_tune_new, folkrnn.div_tune);
-        div_tune_new.removeAttribute('style');
+        div_tune_new.removeAttribute('hidden');
         div_tune_new.scrollIntoView();
         
         // Register for updates
@@ -110,7 +110,7 @@ folkrnn.tuneManager = {
         
         // Reveal about div, if there are no tunes
         if (Object.keys(folkrnn.tuneManager.tunes).length === 0) {
-            folkrnn.div_about.removeAttribute('style');
+            folkrnn.div_about.removeAttribute('hidden');
         } 
     },
 };
@@ -232,18 +232,18 @@ folkrnn.updateTuneDiv = function(tune) {
     el_generated.innerHTML = tune.rnn_finished;
     if (tune.rnn_finished) {
         el_generated.innerHTML = new Date(tune.rnn_finished).toLocaleString();
-        el_requested.parentNode.setAttribute('style', 'display: none');
-        el_generated.parentNode.removeAttribute('style');
+        el_requested.parentNode.setAttribute('hidden', '');
+        el_generated.parentNode.removeAttribute('hidden');
         
         el_archive_title.value = tune.title;
         el_archive_form.setAttribute('action', tune.archive_url);
-        el_archive_form.removeAttribute('style');
+        el_archive_form.removeAttribute('hidden');
     } else {
         el_requested.innerHTML = new Date(tune.requested).toLocaleString();
-        el_requested.parentNode.removeAttribute('style');
-        el_generated.parentNode.setAttribute('style', 'display: none');
+        el_requested.parentNode.removeAttribute('hidden');
+        el_generated.parentNode.setAttribute('hidden', '');
         
-        el_archive_form.setAttribute('style', 'display: none');
+        el_archive_form.setAttribute('hidden', '');
         
         if (!tune.rnn_started) {
             el_abc.innerHTML = folkrnn.waitingABC;

--- a/folk_rnn_site/composer/static/folk_rnn_model_utilities.js
+++ b/folk_rnn_site/composer/static/folk_rnn_model_utilities.js
@@ -130,6 +130,38 @@ folkrnn.parseABC = function(abc) {
 
     // append final part
     result.push(w);
+        
+    // Post-process, for e.g. ':||:' needs to be ':|', '|:'.
+    // From Bob –
+    // sed 's/: |/:|/g' | sed 's/| :/|:/g' |
+    // sed 's/|\[\([0-9]\)/|\1/g' | sed 's/| \[\([0-9]\)/|\1/g' |
+    // sed 's/|\[ \([0-9]\)/|\1/g' | sed 's/| \([0-9]\)/|\1/g' |
+    // sed 's/:|:/:| |:/g' | sed 's/:|\([0-9]\)/:| |\1/g' |
+    // sed 's/::/:| |:/g' | sed 's/|\[/| \[/g' | sed 's/\]\[/\] \[/g' |
+    // sed 's/\]|/\] |/g' | sed 's/|:\[/|: \[/g' | sed 's/\]:|/\] :|/g' |
+    // sed 's/:||:/:| |:/g' | sed 's/\[ \([0-9]\)/|\1/g' | sed 's/-|/- |/g' |
+    // sed 's/||/|/g' | sed 's/-:|/- :|/g'
+    let tokensSpaced = result.join(' ');
+    tokensSpaced = tokensSpaced.replace(/: \|/g, ':|'); // sed 's/: |/:|/g'
+    tokensSpaced = tokensSpaced.replace(/\| :/g, '|:'); // sed 's/| :/|:/g'
+    tokensSpaced = tokensSpaced.replace(/\|\[([0-9])/g, '|$1'); // sed 's/|\[\([0-9]\)/|\1/g'
+    tokensSpaced = tokensSpaced.replace(/\| \[([0-9])/g, '|$1'); // sed 's/| \[\([0-9]\)/|\1/g'
+    tokensSpaced = tokensSpaced.replace(/\|\[ ([0-9])/g, '|$1'); // sed 's/|\[ \([0-9]\)/|\1/g'
+    tokensSpaced = tokensSpaced.replace(/\| ([0-9])/g, '|$1'); // sed 's/| \([0-9]\)/|\1/g'
+    tokensSpaced = tokensSpaced.replace(/:\|:/g, ':| |:'); // sed 's/:|:/:| |:/g'
+    tokensSpaced = tokensSpaced.replace(/:\|([0-9])/g, ':| |$1'); // sed 's/:|\([0-9]\)/:| |\1/g'
+    tokensSpaced = tokensSpaced.replace(/::/g, ':| |:'); // sed 's/::/:| |:/g'
+    tokensSpaced = tokensSpaced.replace(/\|\[/g, '| ['); // sed 's/|\[/| \[/g'
+    tokensSpaced = tokensSpaced.replace(/\]\[/g, '] ['); // sed 's/\]\[/\] \[/g'
+    tokensSpaced = tokensSpaced.replace(/\]\|/g, '] |'); // sed 's/\]|/\] |/g'
+    tokensSpaced = tokensSpaced.replace(/\|:\[/g, '|: ['); // sed 's/|:\[/|: \[/g'
+    tokensSpaced = tokensSpaced.replace(/\]:\|/g, '] :|'); // sed 's/\]:|/\] :|/g'
+    tokensSpaced = tokensSpaced.replace(/:\|\|:/g, ':| |:'); // sed 's/:||:/:| |:/g'
+    tokensSpaced = tokensSpaced.replace(/\[ ([0-9])/g, '|$1'); // sed 's/\[ \([0-9]\)/|\1/g'
+    tokensSpaced = tokensSpaced.replace(/-\|/g, '- |'); // sed 's/-|/- |/g'
+    tokensSpaced = tokensSpaced.replace(/\|\|/g, '|'); // sed 's/||/|/g'
+    tokensSpaced = tokensSpaced.replace(/-:\|/g, '- :|'); //sed 's/-:|/- :|/g'    
+    result = tokensSpaced.split(' ');
 
     return {'tokens': result, 'invalidIndexes': invalidIndexes};
 };

--- a/folk_rnn_site/composer/templates/composer/_compose.html
+++ b/folk_rnn_site/composer/templates/composer/_compose.html
@@ -10,25 +10,28 @@
                 <legend><!-- RNN Properties --></legend>
                 <div class="pure-u-1">
                     <label for="{{ compose_form.model.id_for_label }}">Model</label>
-                    {% render_field compose_form.model class+="pure-input-1" %}
+                    {% render_field compose_form.model class+="pure-input-1" title="Select a network" %}
                 </div>
                 <div class="pure-u-1-2">
                     <label for="{{ compose_form.temp.id_for_label }}">Temperature</label>
-                    {% render_field compose_form.temp class+="pure-input-1" %}
+                    {% render_field compose_form.temp class+="pure-input-1" title="A number between 0.1 and 10 saying how adventurous the generation will be. Ex: 1.0 is normal. 2.0 is more wild. 0.5 is more cautious." %}
                 </div>
                 <div class="pure-u-1-2">
                     <label for="{{ compose_form.seed.id_for_label }}">Seed</label>
-                    {% render_field compose_form.seed class+="pure-input-1" %}
+                    {% render_field compose_form.seed class+="pure-input-1" title="The random number generator seed. Change this number to generate a different tune with the same settings." %}
                 </div>
                 <legend><!-- Tune Properties --></legend>
                 <div class="pure-u-1-2">
-                    {% render_field compose_form.meter class+="pure-input-1" %}
+                    <label for="{{ compose_form.meter.id_for_label }}">Meter</label>
+                    {% render_field compose_form.meter class+="pure-input-1" title="Choose a meter for the tune" %}
                 </div>
                 <div class="pure-u-1-2">
-                    {% render_field compose_form.key class+="pure-input-1" %}
+                    <label for="{{ compose_form.key.id_for_label }}">Mode</label>
+                    {% render_field compose_form.key class+="pure-input-1" title="Choose a mode for the tune" %}
                 </div>
                 <div class="pure-u-1">
-                    {% render_field compose_form.start_abc class+="pure-input-1" rows="3" placeholder="Enter start of tune in ABC notation" %}
+                <label for="{{ compose_form.start_abc.id_for_label }}">Initial ABC</label>
+                    {% render_field compose_form.start_abc class+="pure-input-1" rows="3" placeholder="Enter start of tune in ABC notation" title="Example: |: (3 D E F" %}
                 </div>
                 <legend></legend>
                 <input id="compose_button" type="button" value="Compose..." class="pure-button pure-button-primary pure-input-1">

--- a/folk_rnn_site/composer/templates/composer/_compose.html
+++ b/folk_rnn_site/composer/templates/composer/_compose.html
@@ -3,7 +3,7 @@
         <h1 class="brand-title">Folk RNN</h1>
         <!-- <h2 class="brand-tagline">Compose</h2> -->
         <div id="compose_ui">
-            Compose folk music using a recurrent neural network
+            Generate a folk tune with a recurrent neural network
             <form class="pure-form pure-g">
                 {% load widget_tweaks %}
                 {% csrf_token %}

--- a/folk_rnn_site/composer/templates/composer/_footer.html
+++ b/folk_rnn_site/composer/templates/composer/_footer.html
@@ -2,7 +2,7 @@
     <h1 class="content-subhead">Credits</h1>
     <div class="post-description">
         <p> folk-rnn is a project funded by the <a href="http://www.ahrc.ac.uk/" target="_blank">UK Arts and Humanities Research Council</a>, grant no. <a href="http://gtr.rcuk.ac.uk/projects?ref=AH%2FR004706%2F1" target="_blank">AH/R004706/1: "Engaging three user communities with applications and outcomes of computational music creativity"</a>.</p>
-        <p>See also: <a href="http://themachinefolksession.org">The Machine Folk Session</a>.</p>
-        <p>Web applications by <a href="http://tobyz.net">Toby Harris</a>.</p>
+        <!-- <p>See also: <a href="http://themachinefolksession.org">The Machine Folk Session</a>.</p> -->
+        <p>Web application<!-- s --> by <a href="http://tobyz.net">Toby Harris</a>.</p>
     </div>
 </div>

--- a/folk_rnn_site/composer/templates/composer/_header.html
+++ b/folk_rnn_site/composer/templates/composer/_header.html
@@ -1,7 +1,7 @@
 <div id="header">
     <h1 class="content-subhead">About Folk RNN</h1>
     <div class="post-description">
-        <p>This website lets you generate music using an artificial intelligence called a "recurrent neural network" (RNN). It's called "folk-rnn" because the RNN was trained on over <a href="http://thesession.org" target="_blank">23,000 transcriptions of folk music</a>.</p>
+        <p>This website lets you generate music using an artificial intelligence called a "recurrent neural network" (RNN). It's called "folk-rnn" because the RNN is trained on transcriptions of folk music.</p>
         <p>The transcriptions are in <a href="http://abcnotation.com/wiki/abc:standard:v2.1" target="_blank">ABC format</a>, but also displayed in common notation. You can also copy and paste the ABC <a href="http://mandolintab.net/abcconverter.php" target="_blank">here</a> to transpose it to any key you want. (More technical information, as well as links to several compositions created using this program, can be found at the <a href="https://github.com/IraKorshunova/folk-rnn" target="_blank">folk-rnn project webpage</a>.)</p>
     </div>
 </div>

--- a/folk_rnn_site/composer/templates/composer/_tune.html
+++ b/folk_rnn_site/composer/templates/composer/_tune.html
@@ -38,12 +38,16 @@
         </div>
         <div id=remove_temp>
         <h3 class="content-subhead">Save it <em>(work in progress)</em></h3>
+        <form class="pure-form">
+            <div class="pure-u-17-24"> <!-- should be pure-u-3-4 -->
+            </div>
             <div class="pure-u-1-8">
                 <input id="archive_button" disabled type="button" value="Archive" class="pure-button pure-button-primary pure-input-1">
             </div>
             <div class="pure-u-1-8">
                 <input id="remove_button" type="button" value="Remove" class="pure-button pure-input-1">
             </div>
+        </form>
         </div>
     </section>
 </div>

--- a/folk_rnn_site/composer/templates/composer/_tune.html
+++ b/folk_rnn_site/composer/templates/composer/_tune.html
@@ -8,7 +8,7 @@
             <textarea id="abc" readonly class="pure-u-1" rows="{{ tune_rows }}">{{ tune.abc }}</textarea>
         </div>
         <div id="composition_metadata">
-            <p>The RNN properties were <span id="rnn_model_name" class="post-category">{{ tune.rnn_model_name }}</span> with seed <span id="seed" class="post-category">{{ tune.seed }}</span> and temperature <span id="temp" class="post-category">{{ tune.temp }}</span>.</p>
+            <p>The RNN properties were <span id="rnn_model_name" class="post-category">{{ tune.rnn_model_name|cut:".pickle" }}</span> with seed <span id="seed" class="post-category">{{ tune.seed }}</span> and temperature <span id="temp" class="post-category">{{ tune.temp }}</span>.</p>
             <p>The prime tokens were <span id="prime_tokens" class="post-category">{{ prime_tokens }}</span>.</p>
             <p>Requested on <span id="requested" class="post-category">{{ tune.requested|date:"DATETIME_FORMAT" }}</span>.</p>
             <p>Generated on <span id="generated" class="post-category">{{ tune.rnn_finished|date:"DATETIME_FORMAT" }}</span>.</p>

--- a/folk_rnn_site/composer/templates/composer/_tune.html
+++ b/folk_rnn_site/composer/templates/composer/_tune.html
@@ -20,7 +20,7 @@
             <h3 class="content-subhead">See it</h3>
             <div id="notation"></div>
         </div>
-        <div id=export>
+        <div id=export hidden>
             <h3 class="content-subhead">Save it</h3>
             <form id="archive_form" method="POST" action="{{ tune.archive_url }}" class="pure-form">
                 {% csrf_token %}
@@ -35,6 +35,15 @@
                 </div>
             </form>
             <p class="post-description"><a href="http://themachinefolksession.org">The Machine Folk Session</a> hosts {{ machine_folk_tune_count }} machine originated folk tunes, from folk-rnn and elsewhere, and hand-crafted settings of these tunes. Give your tune here a title, hit 'Archive', and go tweak! It will take you the machine folk session site.</p>
+        </div>
+        <div id=remove_temp>
+        <h3 class="content-subhead">Save it <em>(work in progress)</em></h3>
+            <div class="pure-u-1-8">
+                <input id="archive_button" disabled type="button" value="Archive" class="pure-button pure-button-primary pure-input-1">
+            </div>
+            <div class="pure-u-1-8">
+                <input id="remove_button" type="button" value="Remove" class="pure-button pure-input-1">
+            </div>
         </div>
     </section>
 </div>

--- a/folk_rnn_site/composer/templates/composer/_tune.html
+++ b/folk_rnn_site/composer/templates/composer/_tune.html
@@ -1,7 +1,7 @@
 {% load humanize %}
 {% load hosts %}
 {% load widget_tweaks %}
-<div id="tune" {% if tune_hidden %}style="display: none"{% endif %}>
+<div id="tune" {% if tune_hidden %}hidden{% endif %}>
     <h1 class="content-subhead">Your generated tune</h1>
     <section class="post">
         <div id="composition">
@@ -31,7 +31,7 @@
                     <input id="archive_button" type="submit" value="Archive" class="pure-button pure-button-primary pure-input-1">
                 </div>
                 <div class="pure-u-1-8">
-                    <input id="remove_button" type="button" value="Remove" class="pure-button pure-input-1">
+                    <input id="remove_buttonXXX" type="button" value="Remove" class="pure-button pure-input-1">
                 </div>
             </form>
             <p class="post-description"><a href="http://themachinefolksession.org">The Machine Folk Session</a> hosts {{ machine_folk_tune_count }} machine originated folk tunes, from folk-rnn and elsewhere, and hand-crafted settings of these tunes. Give your tune here a title, hit 'Archive', and go tweak! It will take you the machine folk session site.</p>

--- a/folk_rnn_site/composer/templates/composer/_tune.html
+++ b/folk_rnn_site/composer/templates/composer/_tune.html
@@ -8,7 +8,7 @@
             <textarea id="abc" readonly class="pure-u-1" rows="{{ tune_rows }}">{{ tune.abc }}</textarea>
         </div>
         <div id="composition_metadata">
-            <p>The RNN properties were <span id="rnn_model_name" class="post-category">{{ tune.rnn_model_name }}</span> with seed and temperature <span id="seed" class="post-category">{{ tune.seed }}</span>, <span id="temp" class="post-category">{{ tune.temp }}</span>.</p>
+            <p>The RNN properties were <span id="rnn_model_name" class="post-category">{{ tune.rnn_model_name }}</span> with seed <span id="seed" class="post-category">{{ tune.seed }}</span> and temperature <span id="temp" class="post-category">{{ tune.temp }}</span>.</p>
             <p>The prime tokens were <span id="prime_tokens" class="post-category">{{ prime_tokens }}</span>.</p>
             <p>Requested on <span id="requested" class="post-category">{{ tune.requested|date:"DATETIME_FORMAT" }}</span>.</p>
             <p>Generated on <span id="generated" class="post-category">{{ tune.rnn_finished|date:"DATETIME_FORMAT" }}</span>.</p>

--- a/folk_rnn_site/composer/templates/composer/tune.html
+++ b/folk_rnn_site/composer/templates/composer/tune.html
@@ -1,5 +1,5 @@
 {% extends "composer/home.html" %}
 
 {% block bodyend %}
-<script type="text/javascript">window.addEventListener("load", function () {folkrnn.tuneManager.addTune({{ tune.id }}); folkrnn.initABCJS();}, false);</script>
+<script type="text/javascript">window.addEventListener("load", function () {folkrnn.tuneManager.addTune({{ tune.id }}); folkrnn.tuneManager.enableABCJS({{ tune.id }});}, false);</script>
 {% endblock %}

--- a/folk_rnn_site/composer/tests_async.py
+++ b/folk_rnn_site/composer/tests_async.py
@@ -27,13 +27,13 @@ async def test_folkrnn_consumer():
     await communicator.send_input({'type': 'stop'})
     await communicator.wait()
 
-    with open(TUNE_PATH + f'/with_repeats_{tune.id}_raw') as f:
+    with open(TUNE_PATH + f'/thesession_with_repeats_{tune.id}_raw') as f:
         assert f.read() == FOLKRNN_OUT_RAW
 
     correct_out = FOLKRNN_OUT\
                     .replace('X:1', f'X:{tune.id}')\
                     .replace('№1', f'№{tune.id}')
-    with open(TUNE_PATH + f'/with_repeats_{tune.id}') as f:
+    with open(TUNE_PATH + f'/thesession_with_repeats_{tune.id}') as f:
         assert f.read() == correct_out
 
     tune = RNNTune.objects.last()
@@ -133,7 +133,7 @@ async def test_receive_json_compose_valid():
     content = {
         'command': 'compose',
         'data': {
-            'model': 'with_repeats.pickle',
+            'model': 'thesession_with_repeats.pickle',
             'temp': 0.1,
             'seed': 123,
             'meter': 'M:4/4',
@@ -148,7 +148,7 @@ async def test_receive_json_compose_valid():
     response_data = json.loads(response)
     assert response_data['command'] == 'add_tune'
     assert response_data['tune']['id'] == tune.id
-    assert tune.rnn_model_name == 'with_repeats.pickle'
+    assert tune.rnn_model_name == 'thesession_with_repeats.pickle'
     assert tune.temp == 0.1
     assert tune.seed == 123
     assert tune.prime_tokens == 'M:4/4 K:Cmaj a b c'
@@ -166,7 +166,7 @@ async def test_receive_json_compose_invalid():
     content = {
         'command': 'compose',
         'data': {
-            'model': 'with_repeats.pickle',
+            'model': 'thesession_with_repeats.pickle',
             'temp': 0.1,
             'seed': -1,
             'meter': 'M:4/4',
@@ -180,7 +180,7 @@ async def test_receive_json_compose_invalid():
     content = {
         'command': 'compose',
         'data': {
-            'model': 'with_repeats.pickle',
+            'model': 'thesession_with_repeats.pickle',
             'temp': 0.1,
             'seed': -1,
             'meter': 'M:4/4',
@@ -194,7 +194,7 @@ async def test_receive_json_compose_invalid():
     content = {
         'command': 'compose',
         'data': {
-            'model': 'with_repeats.pickle',
+            'model': 'thesession_with_repeats.pickle',
             'temp': 11,
             'seed': 123,
             'meter': 'M:4/4',

--- a/folk_rnn_site/folk_rnn_site/tests.py
+++ b/folk_rnn_site/folk_rnn_site/tests.py
@@ -5,7 +5,7 @@ from django.contrib.staticfiles import finders
 from folk_rnn_site.models import ABCModel
 
 # Input, output as per https://github.com/tobyspark/folk-rnn/commit/381184a2d6659a47520cedd6d4dfa7bb1c5189f7
-FOLKRNN_IN = {'rnn_model_name': 'with_repeats.pickle', 'seed': 42, 'temp': 1, 'meter': '', 'key': '', 'start_abc': ''}
+FOLKRNN_IN = {'rnn_model_name': 'thesession_with_repeats.pickle', 'seed': 42, 'temp': 1, 'meter': '', 'key': '', 'start_abc': ''}
 FOLKRNN_OUT_RAW = '''M:4/4 K:Cdor c 3 d c 2 B G | G F F 2 G B c d | c 3 d c B G A | B G G F G 2 f e | d 2 c d c B G A | B G F G B F G F | G B c d c d e f | g b f d e 2 e f | d B B 2 B 2 d c | B G G 2 B G F B | d B B 2 c d e f | g 2 f d g f d c | d g g 2 f d B c | d B B 2 B G B c | d f d c B 2 d B | c B B G F B G B | d 2 c d d 2 f d | g e c d e 2 f g | f d d B c 2 d B | d c c B G B B c | d 2 c d d 2 f d | c d c B c 2 d f | g b b 2 g a b d' | c' d' b g f d d f |'''
 FOLKRNN_OUT = '''X:1
 T:Folk RNN Tune №1

--- a/tools/create_model_from_config_meta.py
+++ b/tools/create_model_from_config_meta.py
@@ -7,9 +7,9 @@ import importlib
 import pickle
 
 metadata_paths = [
-        ('/folk_rnn/metadata/config5-wrepeats-20160112-222521.pkl', 'with_repeats'),
-        ('/folk_rnn/metadata/config5-worepeats-20160311-134539.pkl', 'without_repeats'),
-        ('/folk_rnn/metadata/config5_resume-allabcworepeats_parsed_Tallis_trimmed1000-20171228-191847_epoch39.pkl', 'without_repeats_tallis'),
+        ('/folk_rnn/metadata/config5-wrepeats-20160112-222521.pkl', 'thesession_with_repeats', 'thesession.org (w/ :| |:)'),
+        ('/folk_rnn/metadata/config5-worepeats-20160311-134539.pkl', 'thesession_without_repeats', 'thesession.org (w/o :| |:)'),
+        # ('/folk_rnn/metadata/config5_resume-allabcworepeats_parsed_Tallis_trimmed1000-20171228-191847_epoch39.pkl', 'without_repeats_tallis'),
         ]
 
 config_module = 'configurations.config5'
@@ -21,17 +21,18 @@ try:
 except:
     pass
 
-for metadata_path, model_name in metadata_paths: 
+for metadata_path, model_filename, model_displayname in metadata_paths: 
     with open(metadata_path, 'rb') as f:
         metadata = pickle.load(f, encoding='latin1') # latin1 maps 0-255 to unicode 0-255
         
     model = {
+        'name': model_displayname,
         'token2idx': metadata['token2idx'],
         'param_values': metadata['param_values'], 
         'num_layers': config.num_layers, 
         'metadata_path': metadata_path,
     }
     
-    path = os.path.join(model_dir, model_name + '.pickle')
+    path = os.path.join(model_dir, model_filename + '.pickle')
     with open(path, 'wb') as f:
         pickle.dump(model, f)


### PR DESCRIPTION
As per today's meeting
- remove links to machine folk session archive
- max on random seed can be far larger, e.g., 1000000
- fix parsing, e.g., :| |:
- help dialogue for folkrnn fields
- "Compose folk music using a recurrent neural network" --> "Generate a folk tune with a recurrent neural network”
- The "about": "It's called "folk-rnn" because the RNN was trained on over 23,000 transcriptions of folk music." --> "It's called "folk-rnn" because the RNN is trained on transcriptions of folk music." (and remove link to thesession.org)
- Rename the models
- Add "Meter" above the meter field
- Add "Mode" above the mode field
- Add "Initial ABC" above text field
- Help balloon text
