### PR TITLE
Feature: State and URL management

### DIFF
--- a/folk_rnn_site/composer/static/folk_rnn_client.js
+++ b/folk_rnn_site/composer/static/folk_rnn_client.js
@@ -300,7 +300,7 @@ folkrnn.updateTuneDiv = function(tune) {
     
     el_abc.innerHTML = tune.abc;
     el_abc.setAttribute('rows', tune.abc.split(/\r\n|\r|\n/).length - 1);
-    el_model.innerHTML = tune.rnn_model_name;
+    el_model.innerHTML = tune.rnn_model_name.replace('.pickle', '');
     el_seed.innerHTML = tune.seed;
     el_temp.innerHTML = tune.temp;
     el_prime_tokens.innerHTML = tune.prime_tokens;

--- a/folk_rnn_site/composer/static/folk_rnn_client.js
+++ b/folk_rnn_site/composer/static/folk_rnn_client.js
@@ -96,17 +96,16 @@ folkrnn.stateManager = {
         folkrnn.fieldStartABC.value = state.start_abc;
         
         // Apply to tuneManager (i.e. sync tunes on page with state)
-        let tune_ids = Object.keys(folkrnn.tuneManager.tunes);
         for (const tune_id of state.tunes) {
-            if (tune_ids.indexOf(tune_id) === -1)
-                folkrnn.tuneManager.addTune(tune_id);
+            folkrnn.tuneManager.addTune(tune_id);
         }
         for (const tune_id of Object.keys(folkrnn.tuneManager.tunes)) {
             if (state.tunes.indexOf(tune_id) === -1)
                 folkrnn.tuneManager.removeTune(tune_id);
         }
         
-        console.log('applyState()\nstate: ' + state);
+        console.log('applyState()');
+        console.log(state);
     },
 };
 
@@ -114,6 +113,11 @@ folkrnn.tuneManager = {
     'tunes': {},
     'addTune': function (tune_id) {
         "use strict";
+        if (tune_id in folkrnn.tuneManager.tunes) {
+            console.log('Attempt to add tune already in tuneManager')
+            return;
+        }
+        
         // Add tune to manager
         const div_tune_new = folkrnn.div_tune.cloneNode(true);
         div_tune_new.id = "tune_" + tune_id;

--- a/folk_rnn_site/composer/static/folk_rnn_client.js
+++ b/folk_rnn_site/composer/static/folk_rnn_client.js
@@ -28,6 +28,21 @@ folkrnn.initialise = function() {
     folkrnn.div_tune.setAttribute('hidden', '');
     
     folkrnn.websocketConnect();
+    
+    const state = window.history.state;
+    if (state) {
+        folkrnn.fieldModel.value = state.model;
+        folkrnn.fieldTemp.value = state.temp;
+        folkrnn.fieldSeed.value = state.seed;
+        folkrnn.fieldKey.value = state.key;
+        folkrnn.fieldMeter.value = state.meter;
+        folkrnn.fieldStartABC.value = state.start_abc;
+        for (const tune_id of state.tunes) {
+            const tune_ids = Object.keys(folkrnn.tuneManager.tunes)
+            if (tune_ids.indexOf(tune_id) === -1)
+                folkrnn.tuneManager.addTune(tune_id);
+        }
+    }
 };
 
 folkrnn.tuneManager = {

--- a/folk_rnn_site/composer/static/folk_rnn_client.js
+++ b/folk_rnn_site/composer/static/folk_rnn_client.js
@@ -67,6 +67,20 @@ folkrnn.tuneManager = {
                     command: "register_for_tune", 
                     tune_id: tune_id
                     });
+        
+        // Update URL
+        const state = {
+            'model': folkrnn.fieldModel.value,
+            'temp': folkrnn.fieldTemp.value,
+            'seed': folkrnn.fieldSeed.value,
+            'key': folkrnn.fieldKey.value,
+            'meter': folkrnn.fieldMeter.value,
+            'start_abc': folkrnn.fieldStartABC.value,
+            'tunes': Object.keys(folkrnn.tuneManager.tunes),
+        };
+        const title = "";
+        const url = "/tune/" + tune_id;
+        window.history.pushState(state, title, url);
     },
     'tuneDiv': function (tune_id) {
         "use strict";
@@ -115,7 +129,22 @@ folkrnn.tuneManager = {
         // Reveal about div, if there are no tunes
         if (Object.keys(folkrnn.tuneManager.tunes).length === 0) {
             folkrnn.div_about.removeAttribute('hidden');
-        } 
+        }
+        
+        // Update URL
+        const state = {
+            'model': folkrnn.fieldModel.value,
+            'temp': folkrnn.fieldTemp.value,
+            'seed': folkrnn.fieldSeed.value,
+            'key': folkrnn.fieldKey.value,
+            'meter': folkrnn.fieldMeter.value,
+            'start_abc': folkrnn.fieldStartABC.value,
+            'tunes': Object.keys(folkrnn.tuneManager.tunes),
+        };
+        const title = "";
+        const tune_ids = Object.keys(folkrnn.tuneManager.tunes);
+        const url = (tune_ids.length === 0) ? "/" : "/tune/" + Math.max(...tune_ids)
+        window.history.pushState(state, title, url);
     },
 };
 

--- a/folk_rnn_site/composer/static/folk_rnn_websocket_utilities.js
+++ b/folk_rnn_site/composer/static/folk_rnn_websocket_utilities.js
@@ -45,8 +45,7 @@ folkrnn.websocketReceive = function(action, stream) {
     if (action.command == "generation_status") {
         if (action.status == "start") {
             folkrnn.updateTuneDiv(action.tune);
-        }
-        
+        }   
         if (action.status == "finish") {
             folkrnn.updateTuneDiv(action.tune);
             folkrnn.tuneManager.enableABCJS(action.tune.id);

--- a/folk_rnn_site/composer/static/folk_rnn_websocket_utilities.js
+++ b/folk_rnn_site/composer/static/folk_rnn_websocket_utilities.js
@@ -37,7 +37,6 @@ folkrnn.websocketSend = function(json) {
 
 folkrnn.websocketReceive = function(action, stream) {
     "use strict";
-    
     if (action.command == "add_tune") {
         folkrnn.stateManager.addTune(action.tune.id);
         folkrnn.updateTuneDiv(action.tune);

--- a/folk_rnn_site/composer/static/folk_rnn_websocket_utilities.js
+++ b/folk_rnn_site/composer/static/folk_rnn_websocket_utilities.js
@@ -39,7 +39,7 @@ folkrnn.websocketReceive = function(action, stream) {
     "use strict";
     
     if (action.command == "add_tune") {
-        folkrnn.tuneManager.addTune(action.tune.id);
+        folkrnn.stateManager.addTune(action.tune.id);
         folkrnn.updateTuneDiv(action.tune);
     }
     if (action.command == "generation_status") {

--- a/folk_rnn_site/composer/templates/composer/_tune.html
+++ b/folk_rnn_site/composer/templates/composer/_tune.html
@@ -1,17 +1,15 @@
-{% load humanize %}
-{% load hosts %}
 {% load widget_tweaks %}
-<div id="tune" {% if tune_hidden %}hidden{% endif %}>
+<div id="tune" hidden>
     <h1 class="content-subhead">Your generated tune</h1>
     <section class="post">
         <div id="composition">
-            <textarea id="abc" readonly class="pure-u-1" rows="{{ tune_rows }}">{{ tune.abc }}</textarea>
+            <textarea id="abc" readonly class="pure-u-1" rows="1"></textarea>
         </div>
         <div id="composition_metadata">
-            <p>The RNN properties were <span id="rnn_model_name" class="post-category">{{ tune.rnn_model_name|cut:".pickle" }}</span> with seed <span id="seed" class="post-category">{{ tune.seed }}</span> and temperature <span id="temp" class="post-category">{{ tune.temp }}</span>.</p>
-            <p>The prime tokens were <span id="prime_tokens" class="post-category">{{ prime_tokens }}</span>.</p>
-            <p>Requested on <span id="requested" class="post-category">{{ tune.requested|date:"DATETIME_FORMAT" }}</span>.</p>
-            <p>Generated on <span id="generated" class="post-category">{{ tune.rnn_finished|date:"DATETIME_FORMAT" }}</span>.</p>
+            <p>The RNN properties were <span id="rnn_model_name" class="post-category"></span> with seed <span id="seed" class="post-category"></span> and temperature <span id="temp" class="post-category"></span>.</p>
+            <p>The prime tokens were <span id="prime_tokens" class="post-category"></span>.</p>
+            <p>Requested on <span id="requested" class="post-category"></span>.</p>
+            <p>Generated on <span id="generated" class="post-category"></span>.</p>
         </div>
         <div id="abcjs_divs">
             <h3 class="content-subhead">Hear it</h3>
@@ -22,7 +20,7 @@
         </div>
         <div id=export hidden>
             <h3 class="content-subhead">Save it</h3>
-            <form id="archive_form" method="POST" action="{{ tune.archive_url }}" class="pure-form">
+            <form id="archive_form" method="POST" action="" class="pure-form">
                 {% csrf_token %}
                 <div class="pure-u-17-24"> <!-- should be pure-u-3-4 -->
                     {% render_field archive_form.title class+="pure-input-1" %}

--- a/folk_rnn_site/composer/templates/composer/home.html
+++ b/folk_rnn_site/composer/templates/composer/home.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         
-        <title>Folk RNN – {% block title %}Compose folk music with a recurrent neural network{% endblock %}</title>
+        <title>Folk RNN – {% block title %}Generate folk tunes with a recurrent neural network{% endblock %}</title>
         
         <link rel="stylesheet" href="/static/pure/pure-min.css">
         <link rel="stylesheet" href="/static/composer.css">

--- a/folk_rnn_site/composer/templates/composer/tune.html
+++ b/folk_rnn_site/composer/templates/composer/tune.html
@@ -1,5 +1,5 @@
 {% extends "composer/home.html" %}
 
 {% block bodyend %}
-<script type="text/javascript">window.addEventListener("load", function () {folkrnn.stateManager.addTune({{ tune_id }}); folkrnn.updateTuneDiv({{ tune_json|safe }}); folkrnn.tuneManager.enableABCJS({{ tune_id }});}, false);</script>
+<script type="text/javascript">window.addEventListener("load", function () {folkrnn.stateManager.addTune({{ tune_id }});}, false);</script>
 {% endblock %}

--- a/folk_rnn_site/composer/templates/composer/tune.html
+++ b/folk_rnn_site/composer/templates/composer/tune.html
@@ -1,5 +1,5 @@
 {% extends "composer/home.html" %}
 
 {% block bodyend %}
-<script type="text/javascript">window.addEventListener("load", function () {folkrnn.stateManager.addTune({{ tune.id }}); folkrnn.tuneManager.enableABCJS({{ tune.id }});}, false);</script>
+<script type="text/javascript">window.addEventListener("load", function () {folkrnn.stateManager.addTune({{ tune_id }}); folkrnn.updateTuneDiv({{ tune_json|safe }}); folkrnn.tuneManager.enableABCJS({{ tune_id }});}, false);</script>
 {% endblock %}

--- a/folk_rnn_site/composer/templates/composer/tune.html
+++ b/folk_rnn_site/composer/templates/composer/tune.html
@@ -1,5 +1,5 @@
 {% extends "composer/home.html" %}
 
 {% block bodyend %}
-<script type="text/javascript">window.addEventListener("load", function () {folkrnn.tuneManager.addTune({{ tune.id }}); folkrnn.tuneManager.enableABCJS({{ tune.id }});}, false);</script>
+<script type="text/javascript">window.addEventListener("load", function () {folkrnn.stateManager.addTune({{ tune.id }}); folkrnn.tuneManager.enableABCJS({{ tune.id }});}, false);</script>
 {% endblock %}

--- a/folk_rnn_site/composer/tests.py
+++ b/folk_rnn_site/composer/tests.py
@@ -44,14 +44,8 @@ class ViewsTest(TestCase):
         
         response = self.client.get(f'/tune/{RNNTune.objects.last().id}')
         self.assertTemplateUsed(response, 'composer/tune.html')
-        #print(response.content)
-        self.assertContains(response,mint_abc()) # django widget inserts a newline; a django workaround to an html workaround beyond the scope of this project
-        self.assertContains(response,'with_repeats.pickle')
-        self.assertContains(response,'123')
-        self.assertContains(response,'0.1')
-        self.assertContains(response, mint_abc())
-        # Testing date is beyond the remit of datetime.strttime(), e.g. day of the week without leading zero.
-    
+        # Tune div and contents are created dynamically, i.e. no further test here.
+        
     def test_tune_page_can_save_a_POST_request(self):
         folk_rnn_create_tune()
         folk_rnn_task_start_mock()

--- a/folk_rnn_site/composer/views.py
+++ b/folk_rnn_site/composer/views.py
@@ -27,8 +27,7 @@ def tune_page(request, tune_id=None):
         'compose_form': ComposeForm(),
         'archive_form': ArchiveForm(),
         'machine_folk_tune_count': Tune.objects.count(),
-        'tune_id': tune_id_int,
-        'tune_json': json.dumps(tune.plain_dict()),
+        'tune_id': tune.id,
         })
 
 def archive_tune(request, tune_id=None):

--- a/folk_rnn_site/composer/views.py
+++ b/folk_rnn_site/composer/views.py
@@ -1,3 +1,4 @@
+import json
 from django.shortcuts import redirect, render
 from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
@@ -11,9 +12,6 @@ from archiver.models import Tune
 def home_page(request):
     return render(request, 'composer/home.html', {
                                 'compose_form': ComposeForm(),
-                                'tune': None,
-                                'tune_rows': 1,
-                                'tune_hidden': True,
                                 'archive_form': ArchiveForm(),
                                 'machine_folk_tune_count': Tune.objects.count(),
                                 })
@@ -27,10 +25,10 @@ def tune_page(request, tune_id=None):
 
     return render(request, 'composer/tune.html', {
         'compose_form': ComposeForm(),
-        'tune': tune,
-        'tune_rows': tune.abc.count('\n'),
-        'archive_form': ArchiveForm({'folkrnn_id': tune_id_int, 'title': tune.title}),
-        'machine_folk_tune_count': Tune.objects.count()
+        'archive_form': ArchiveForm(),
+        'machine_folk_tune_count': Tune.objects.count(),
+        'tune_id': tune_id_int,
+        'tune_json': json.dumps(tune.plain_dict()),
         })
 
 def archive_tune(request, tune_id=None):


### PR DESCRIPTION
Uses browser's history API to maintain state throughout and update URLs on compose.
- e.g. navigating away and back should not lose the workspace.
- e.g. quitting and starting the browser should not lose the workspace when a recently closed URL is reopened.

Plus tweaks
- '.pickle' no longer displayed as part of model name
- page title updated for 'generate' rather than 'compose' byline
- attempts to maintain key, meter selection on model change