### PR TITLE
Workaround: django-embed-video fails on https when behind reverse proxy

### DIFF
--- a/folk_rnn_site/archiver/templates/archiver/recordings.html
+++ b/folk_rnn_site/archiver/templates/archiver/recordings.html
@@ -18,7 +18,7 @@
         <p class="meta">Added by <a href="#">{{ recording.author.get_full_name }}</a>.</p> 
     </div>
     <div class="section-body">
-        {% video recording.video as my_video %}
+        {% video recording.video is_secure=True as my_video %}
           {% video my_video%}
           <p class="meta"><a href="{{ recording.video }}">View on {{ my_video.backend | cut:"Backend" }}</a></p>
         {% endvideo %}

--- a/tools/provision_folkrnn.sh
+++ b/tools/provision_folkrnn.sh
@@ -54,7 +54,12 @@ pip3.6 install "channels_redis"
 pip3.6 install "pytest-django" "pytest-asyncio"
 pip3.6 install psycopg2-binary
 pip3.6 install google-api-python-client google-auth google-auth-httplib2
-pip3.6 install django-embed-video
+
+# See https://github.com/jazzband/django-embed-video/issues/87
+# pip3.6 install django-embed-video
+apt-get install --yes git
+pip3.6 install git+https://github.com/tobyspark/django-embed-video.git
+
 pip3.6 install django-markdown-deux
 pip3.6 install pillow
 apt-get install --yes postgresql


### PR DESCRIPTION
See – https://github.com/jazzband/django-embed-video/issues/87