### PR TITLE
Feature search

### DIFF
--- a/folk_rnn_site/archiver/forms.py
+++ b/folk_rnn_site/archiver/forms.py
@@ -48,7 +48,7 @@ class EventForm(forms.Form):
 class TunebookForm(forms.Form):
     add = forms.BooleanField(required=False)
 
-class TuneSearchForm(forms.Form):
+class SearchForm(forms.Form):
     search = forms.CharField(required=False)
 
 # As per registration docs, this should subclass registration.forms.RegistrationFormUniqueEmail.

--- a/folk_rnn_site/archiver/forms.py
+++ b/folk_rnn_site/archiver/forms.py
@@ -48,6 +48,9 @@ class EventForm(forms.Form):
 class TunebookForm(forms.Form):
     add = forms.BooleanField(required=False)
 
+class TuneSearchForm(forms.Form):
+    search = forms.CharField(required=False)
+
 # As per registration docs, this should subclass registration.forms.RegistrationFormUniqueEmail.
 # That wasn't working, so here instead is an equivalent, based on some of that code.
 def validate_duplicate_email(value):

--- a/folk_rnn_site/archiver/templates/archiver/_tunepreviews.html
+++ b/folk_rnn_site/archiver/templates/archiver/_tunepreviews.html
@@ -17,7 +17,7 @@
     {% endif %}
     </li>
     {% empty %}
-    <li><p>No tunes</p></li>
+    <li><p>{{ empty_message|default:'No tunes' }}</p></li>
     {% endfor %}
     <script type="text/javascript">
     window.addEventListener("load", function() {

--- a/folk_rnn_site/archiver/templates/archiver/_tunepreviews.html
+++ b/folk_rnn_site/archiver/templates/archiver/_tunepreviews.html
@@ -4,15 +4,15 @@
     <li>
     {% if item.rnn_tune %}{# tune model from folk-rnn #}
     <h3><a href="{% url 'tune' tune_id=item.id %}">{{item.title_or_mfsession}}</a></h3>
-    <div id="notation-{{ forloop.counter }}"></div>
+    <div id="notation-{{ id_prefix }}{{ forloop.counter }}"></div>
     <p class="meta">Tune submitted from <a href="{{ item.rnn_tune.url }}">folkrnn.org</a> {{ item.submitted|naturalday }}</p>
     {% elif not item.tune %}{# tune model not from folk-rnn #}
     <h3><a href="{% url 'tune' tune_id=item.id %}">{{item.title_or_mfsession}}</a></h3>
-    <div id="notation-{{ forloop.counter }}"></div>
+    <div id="notation-{{ id_prefix }}{{ forloop.counter }}"></div>
     <p class="meta">Original tune submitted {{ item.submitted|naturalday }}</p>
     {% else %}{# setting model #}
     <h3><a href="{% url 'tune' tune_id=item.tune.id %}">{{item.title}}</a></h3>
-    <div id="notation-{{ forloop.counter }}"></div>
+    <div id="notation-{{ id_prefix }}{{ forloop.counter }}"></div>
     <p class="meta">Setting of <a href="{% url 'tune' tune_id=item.tune.id %}">{{ item.tune.title }}</a> added by <a href="{% url 'user' user_id=item.author.id %}">{{ item.author.get_full_name }}</a> {{ item.submitted|naturalday }}.</p>
     {% endif %}
     </li>
@@ -27,7 +27,7 @@
             responsive: "resize",
         }
         {% for item in tunes_settings %}
-        ABCJS.renderAbc("notation-{{ forloop.counter }}", "{{ item.abc_trimmed|escapejs }}", params);
+        ABCJS.renderAbc("notation-{{ id_prefix }}{{ forloop.counter }}", "{{ item.abc_trimmed|escapejs }}", params);
         {% endfor %}
     }, false);
     </script>

--- a/folk_rnn_site/archiver/templates/archiver/recording.html
+++ b/folk_rnn_site/archiver/templates/archiver/recording.html
@@ -1,0 +1,7 @@
+{% extends "archiver/base.html" %}
+
+{% block title %}Recordings{% endblock %}
+
+{% block content %}
+{% include 'archiver/_recording.html' %}
+{% endblock %}

--- a/folk_rnn_site/archiver/templates/archiver/recordings.html
+++ b/folk_rnn_site/archiver/templates/archiver/recordings.html
@@ -25,11 +25,10 @@
         {% if search_text %}
         <p class="meta">{{ search_results.paginator.count|apnumber|capfirst }} matching recording{{ search_results.paginator.count|pluralize }} found</p>
         {% else %}
-        <p class="meta">Search through recordings, the names of events they were recorded at, and the tunes they contain. Currently showing all recordings</p>
+        <p class="meta">Search through recordings, the names of events they were recorded at, and the tunes they contain. Currently showing all recordings.</p>
         {% endif %}
     </div>
 </div>
-
 
 {% for recording in search_results %}
 {% include 'archiver/_recording.html' %}

--- a/folk_rnn_site/archiver/templates/archiver/recordings.html
+++ b/folk_rnn_site/archiver/templates/archiver/recordings.html
@@ -3,7 +3,35 @@
 {% block title %}Recordings{% endblock %}
 
 {% block content %}
-{% for recording in recordings %}
+{% load widget_tweaks %}
+{% load humanize %}
+<div id="search-tune" class="section">
+    <div class="section-meta">
+    <h2>Recording search</h2>
+    {% if search_results.paginator.num_pages > 1 %}
+    <p class="meta">Page {{ search_results.number }} of {{ search_results.paginator.num_pages }}<br>
+    {% if search_results.has_previous %}<a href="?search={{ search_text|urlencode:'' }}&page={{ search_results.previous_page_number }}">previous</a>{% endif %}{% if search_results.has_previous and search_results.has_next %} | {% endif %}{% if search_results.has_next %}<a href="?search={{ search_text|urlencode:'' }}&page={{ search_results.next_page_number }}">next</a>{% endif %}</p>
+    {% endif %}
+    </div>
+    <div class="section-body">
+        <form method="get" class="pure-form"> 
+        <div class="pure-u-17-24">
+            {% render_field search_form.search class+="pure-input-1" title="Add text to search recordings by" placeholder=search_placeholder %}
+        </div>
+        <div class="pure-u-1-4">
+            <input type="submit" value="Search" class="pure-button pure-button-primary pure-input-1"/>
+        </div>
+        </form>
+        {% if search_text %}
+        <p class="meta">{{ search_results.paginator.count|apnumber|capfirst }} matching recording{{ search_results.paginator.count|pluralize }} found</p>
+        {% else %}
+        <p class="meta">Search through recordings, the names of events they were recorded at, and the tunes they contain. Currently showing all recordings</p>
+        {% endif %}
+    </div>
+</div>
+
+
+{% for recording in search_results %}
 {% include 'archiver/_recording.html' %}
 {% endfor %}
 {% endblock %}

--- a/folk_rnn_site/archiver/templates/archiver/tunes.html
+++ b/folk_rnn_site/archiver/templates/archiver/tunes.html
@@ -19,7 +19,7 @@
             </div>
             </form>
             {% if search_results %}
-            {% include 'archiver/_tunepreviews.html' with tunes_settings=search_results %}
+            {% include 'archiver/_tunepreviews.html' with tunes_settings=search_results id_prefix='search' %}
             {% endif %}
         </div>
     </div>

--- a/folk_rnn_site/archiver/templates/archiver/tunes.html
+++ b/folk_rnn_site/archiver/templates/archiver/tunes.html
@@ -16,7 +16,7 @@
         <div class="section-body">
             <form method="get" class="pure-form"> 
             <div class="pure-u-17-24">
-                {% render_field tunesearch_form.search class+="pure-input-1" title="Search text in title, notes" placeholder=search_placeholder %}
+                {% render_field search_form.search class+="pure-input-1" title="Add text to search tunes by" placeholder=search_placeholder %}
             </div>
             <div class="pure-u-1-4">
                 <input type="submit" value="Search" class="pure-button pure-button-primary pure-input-1"/>

--- a/folk_rnn_site/archiver/templates/archiver/tunes.html
+++ b/folk_rnn_site/archiver/templates/archiver/tunes.html
@@ -8,6 +8,10 @@
     <div id="search-tune" class="section">
         <div class="section-meta">
         <h2>Tune search</h2>
+        {% if search_results.paginator.num_pages > 1 %}
+        <p class="meta">Page {{ search_results.number }} of {{ search_results.paginator.num_pages }}<br>
+        {% if search_results.has_previous %}<a href="?search={{ search_text|urlencode:'' }}&page={{ search_results.previous_page_number }}">previous</a>{% endif %}{% if search_results.has_previous and search_results.has_next %} | {% endif %}{% if search_results.has_next %}<a href="?search={{ search_text|urlencode:'' }}&page={{ search_results.next_page_number }}">next</a>{% endif %}</p>
+        {% endif %}
         </div>
         <div class="section-body">
             <form method="get" class="pure-form"> 
@@ -22,7 +26,7 @@
             {% if search_results %}
             {% include 'archiver/_tunepreviews.html' with tunes_settings=search_results id_prefix='search' %}
             {% else %}
-            <p class="meta">Search through tunes, their settings, notes or comments.
+            <p class="meta">Search through tunes, settings of those tunes, or their notes or comments.
             {% endif %}
             </div>
         </div>

--- a/folk_rnn_site/archiver/templates/archiver/tunes.html
+++ b/folk_rnn_site/archiver/templates/archiver/tunes.html
@@ -12,7 +12,7 @@
         <div class="section-body">
             <form method="get" class="pure-form"> 
             <div class="pure-u-17-24">
-                {% render_field tunesearch_form.search class+="pure-input-1" title="Search text in title, notes" placeholder="e.g. DeepBach" %}
+                {% render_field tunesearch_form.search class+="pure-input-1" title="Search text in title, notes" placeholder=search_placeholder %}
             </div>
             <div class="pure-u-1-4">
                 <input type="submit" value="Search" class="pure-button pure-button-primary pure-input-1"/>

--- a/folk_rnn_site/archiver/templates/archiver/tunes.html
+++ b/folk_rnn_site/archiver/templates/archiver/tunes.html
@@ -23,8 +23,8 @@
             </div>
             </form>
             <div id="search-results">
-            {% if search_results %}
-            {% include 'archiver/_tunepreviews.html' with tunes_settings=search_results id_prefix='search' %}
+            {% if search_text %}
+            {% include 'archiver/_tunepreviews.html' with tunes_settings=search_results id_prefix='search' empty_message='No matches found' %}
             {% else %}
             <p class="meta">Search through tunes, settings of those tunes, or their notes or comments.
             {% endif %}

--- a/folk_rnn_site/archiver/templates/archiver/tunes.html
+++ b/folk_rnn_site/archiver/templates/archiver/tunes.html
@@ -2,15 +2,35 @@
 
 {% block title %}Tunes{% endblock %}
 
-
 {% block content %}
+{% load widget_tweaks %}
+<div id="search">
+    <div id="search-tune" class="section">
+        <div class="section-meta">
+        <h2>Tune search</h2>
+        </div>
+        <div class="section-body">
+            <form method="get" class="pure-form"> 
+            <div class="pure-u-17-24">
+                {% render_field tunesearch_form.search class+="pure-input-1" title="Search text in title, notes" placeholder="e.g. DeepBach" %}
+            </div>
+            <div class="pure-u-1-4">
+                <input type="submit" value="Search" class="pure-button pure-button-primary pure-input-1"/>
+            </div>
+            </form>
+            {% if search_results %}
+            {% include 'archiver/_tunepreviews.html' with tunes_settings=search_results %}
+            {% endif %}
+        </div>
+    </div>
+</div> 
 <div id="activity">
     <div id="recent-tunes" class="section">
         <div class="section-meta">
         <h2>Recent tunes</h2>
         </div>
         <div class="section-body">
-            {% include "archiver/_tunepreviews.html" %}
+            {% include "archiver/_tunepreviews.html" with tunes_settings=recent_tunes%}
         </div>
     </div>
     <div id="recent-comments"  class="section">

--- a/folk_rnn_site/archiver/templates/archiver/tunes.html
+++ b/folk_rnn_site/archiver/templates/archiver/tunes.html
@@ -4,6 +4,7 @@
 
 {% block content %}
 {% load widget_tweaks %}
+{% load humanize %}
 <div id="search">
     <div id="search-tune" class="section">
         <div class="section-meta">
@@ -24,36 +25,14 @@
             </form>
             <div id="search-results">
             {% if search_text %}
-            {% include 'archiver/_tunepreviews.html' with tunes_settings=search_results id_prefix='search' empty_message='No matches found' %}
+            <p class="meta">{{ search_results.paginator.count|apnumber|capfirst }} matching recording{{ search_results.paginator.count|pluralize }} found</p>
             {% else %}
-            <p class="meta">Search through tunes, settings of those tunes, or their notes or comments.
+            <p class="meta">Search through tunes, settings of those tunes, or their notes or comments. Currently showing all tunes.
             {% endif %}
+            <p>&nbsp;</p>
+            {% include 'archiver/_tunepreviews.html' with tunes_settings=search_results id_prefix='search' empty_message='No matches found' %}
             </div>
         </div>
     </div>
 </div> 
-<div id="activity">
-    <div id="recent-tunes" class="section">
-        <div class="section-meta">
-        <h2>Recent tunes</h2>
-        </div>
-        <div class="section-body">
-            {% include "archiver/_tunepreviews.html" with tunes_settings=recent_tunes%}
-        </div>
-    </div>
-    <div id="recent-comments"  class="section">
-        <div class="section-meta">
-            <h2>Recent comments</h2>
-        </div>
-        <div class="section-body">
-            {% include "archiver/_commentpreviews.html" %}      
-        </div>
-    </div>
-</div>
-{# Can't put this inline as render_field trips on the quotes #}
-<script type="text/javascript">
-    document.getElementById('id_search').addEventListener('input', function() {
-        document.getElementById('search-results').innerHTML = ''
-    }, false);
-</script>
 {% endblock %}

--- a/folk_rnn_site/archiver/templates/archiver/tunes.html
+++ b/folk_rnn_site/archiver/templates/archiver/tunes.html
@@ -21,6 +21,8 @@
             <div id="search-results">
             {% if search_results %}
             {% include 'archiver/_tunepreviews.html' with tunes_settings=search_results id_prefix='search' %}
+            {% else %}
+            <p class="meta">Search through tunes, their settings, notes or comments.
             {% endif %}
             </div>
         </div>

--- a/folk_rnn_site/archiver/templates/archiver/tunes.html
+++ b/folk_rnn_site/archiver/templates/archiver/tunes.html
@@ -18,9 +18,11 @@
                 <input type="submit" value="Search" class="pure-button pure-button-primary pure-input-1"/>
             </div>
             </form>
+            <div id="search-results">
             {% if search_results %}
             {% include 'archiver/_tunepreviews.html' with tunes_settings=search_results id_prefix='search' %}
             {% endif %}
+            </div>
         </div>
     </div>
 </div> 
@@ -41,5 +43,11 @@
             {% include "archiver/_commentpreviews.html" %}      
         </div>
     </div>
-</div> 
+</div>
+{# Can't put this inline as render_field trips on the quotes #}
+<script type="text/javascript">
+    document.getElementById('id_search').addEventListener('input', function() {
+        document.getElementById('search-results').innerHTML = ''
+    }, false);
+</script>
 {% endblock %}

--- a/folk_rnn_site/archiver/views.py
+++ b/folk_rnn_site/archiver/views.py
@@ -63,6 +63,7 @@ def tunes_page(request):
             ).filter(
                 search=SearchQuery(search_text)
             ).order_by('-id').distinct('id')
+        add_abc_trimmed(search_results)
     else:
         search_results = None
     

--- a/folk_rnn_site/archiver/views.py
+++ b/folk_rnn_site/archiver/views.py
@@ -59,7 +59,7 @@ def tunes_page(request):
     if 'search' in request.GET and request.GET['search'] != '':
         search_text = request.GET['search']
         search_results = Tune.objects.annotate(
-                search=SearchVector('abc', 'setting__abc', 'tuneattribution__text')
+                search=SearchVector('abc', 'setting__abc', 'tuneattribution__text', 'comment__text')
             ).filter(
                 search=SearchQuery(search_text)
             ).order_by('-id').distinct('id')

--- a/folk_rnn_site/archiver/views.py
+++ b/folk_rnn_site/archiver/views.py
@@ -64,29 +64,27 @@ def tunes_page(request):
             ).filter(
                 search=SearchQuery(search_text)
             ).order_by('-id').distinct('id')
-        add_abc_trimmed(search_results)
-        paginator = Paginator(search_results, TUNE_PREVIEWS_PER_PAGE)
-        page_number = request.GET.get('page')
-        try:
-            search_results_page = paginator.page(page_number)
-        except PageNotAnInteger:
-            search_results_page = paginator.page(1)
-        except EmptyPage:
-            search_results_page = paginator.page(paginator.num_pages)
     else:
-        search_text = None
-        search_results_page = None
+        search_text = ''
+        search_results = Tune.objects.all()
+        
+    paginator = Paginator(search_results, TUNE_PREVIEWS_PER_PAGE)
+    page_number = request.GET.get('page')
+    try:
+        search_results_page = paginator.page(page_number)
+    except PageNotAnInteger:
+        search_results_page = paginator.page(1)
+    except EmptyPage:
+        search_results_page = paginator.page(paginator.num_pages)
+    add_abc_trimmed(search_results_page)
     
     search_placeholders = ['DeepBach', 'Glas Herry', 'M:3/4', 'K:Cmix', 'G/A/G/F/ ED', 'dBd edc']
     search_placeholder = f'e.g. {choice(search_placeholders)}'
-    recent_tunes, comments = activity()
     return render(request, 'archiver/tunes.html', {
                             'search_form': SearchForm(request.GET),
                             'search_text': search_text,
                             'search_placeholder': search_placeholder,
                             'search_results': search_results_page,
-                            'recent_tunes': recent_tunes,
-                            'comments': comments,
                             })
 
 def tune_page(request, tune_id=None):

--- a/folk_rnn_site/archiver/views.py
+++ b/folk_rnn_site/archiver/views.py
@@ -9,6 +9,7 @@ from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from tempfile import TemporaryFile
 from itertools import chain
 from datetime import timedelta
+from random import choice
 
 from folk_rnn_site.models import ABCModel, conform_abc
 from archiver import MAX_RECENT_ITEMS, TUNE_PREVIEWS_PER_PAGE
@@ -67,9 +68,12 @@ def tunes_page(request):
     else:
         search_results = None
     
+    search_placeholders = ['DeepBach', 'Glas Herry', 'M:3/4', 'K:Cmix', 'G/A/G/F/ ED', 'dBd edc']
+    search_placeholder = f'e.g. {choice(search_placeholders)}'
     recent_tunes, comments = activity()
     return render(request, 'archiver/tunes.html', {
                             'tunesearch_form': TuneSearchForm(request.GET),
+                            'search_placeholder': search_placeholder,
                             'search_results': search_results,
                             'recent_tunes': recent_tunes,
                             'comments': comments,

--- a/folk_rnn_site/archiver/views.py
+++ b/folk_rnn_site/archiver/views.py
@@ -66,7 +66,7 @@ def tunes_page(request):
             ).order_by('-id').distinct('id')
     else:
         search_text = ''
-        search_results = Tune.objects.all()
+        search_results = Tune.objects.order_by('-id')
         
     paginator = Paginator(search_results, TUNE_PREVIEWS_PER_PAGE)
     page_number = request.GET.get('page')
@@ -287,7 +287,7 @@ def recordings_page(request):
             ).order_by('-id').distinct('id')
     else:
         search_text = ''
-        search_results = Recording.objects.all()
+        search_results = Recording.objects.order_by('-id')
     
     paginator = Paginator(search_results, TUNE_PREVIEWS_PER_PAGE)
     page_number = request.GET.get('page')

--- a/folk_rnn_site/archiver/views.py
+++ b/folk_rnn_site/archiver/views.py
@@ -65,16 +65,26 @@ def tunes_page(request):
                 search=SearchQuery(search_text)
             ).order_by('-id').distinct('id')
         add_abc_trimmed(search_results)
+        paginator = Paginator(search_results, TUNE_PREVIEWS_PER_PAGE)
+        page_number = request.GET.get('page')
+        try:
+            search_results_page = paginator.page(page_number)
+        except PageNotAnInteger:
+            search_results_page = paginator.page(1)
+        except EmptyPage:
+            search_results_page = paginator.page(paginator.num_pages)
     else:
-        search_results = None
+        search_text = None
+        search_results_page = None
     
     search_placeholders = ['DeepBach', 'Glas Herry', 'M:3/4', 'K:Cmix', 'G/A/G/F/ ED', 'dBd edc']
     search_placeholder = f'e.g. {choice(search_placeholders)}'
     recent_tunes, comments = activity()
     return render(request, 'archiver/tunes.html', {
                             'tunesearch_form': TuneSearchForm(request.GET),
+                            'search_text': search_text,
                             'search_placeholder': search_placeholder,
-                            'search_results': search_results,
+                            'search_results': search_results_page,
                             'recent_tunes': recent_tunes,
                             'comments': comments,
                             })


### PR DESCRIPTION
Reworked `/tunes` and `/recordings`
- search bar on top
- paginated tunes/recordings below
- shows all entries when no search term

`/recordings` should be the same, doesn’t make sense yet given few recordings.