### PR TITLE
Tweak: Bob's admin user sort

### DIFF
--- a/folk_rnn_site/archiver/admin.py
+++ b/folk_rnn_site/archiver/admin.py
@@ -50,6 +50,6 @@ class UserAdmin(DjangoUserAdmin):
             'fields': ('email', 'password1', 'password2'),
         }),
     )
-    list_display = ('email', 'first_name', 'last_name', 'is_staff')
+    list_display = ('email', 'first_name', 'last_name', 'date_joined', 'is_staff')
     search_fields = ('email', 'first_name', 'last_name')
     ordering = ('email',)


### PR DESCRIPTION
Shows a date joined column in the Admin Users page. Sortable. Fixes #76  