### PR TITLE
Feature: tunes page has order by added or popularity

### DIFF
--- a/folk_rnn_site/archiver/templates/archiver/tunes.html
+++ b/folk_rnn_site/archiver/templates/archiver/tunes.html
@@ -14,7 +14,7 @@
         <h2>Tune search</h2>
         {% if search_results.paginator.num_pages > 1 %}
         <p class="meta">Page {{ search_results.number }} of {{ search_results.paginator.num_pages }}<br>
-        {% if search_results.has_previous %}<a href="?search={{ search_text|urlencode:'' }}&page={{ search_results.previous_page_number }}">previous</a>{% endif %}{% if search_results.has_previous and search_results.has_next %} | {% endif %}{% if search_results.has_next %}<a href="?search={{ search_text|urlencode:'' }}&page={{ search_results.next_page_number }}">next</a>{% endif %}</p>
+        {% if search_results.has_previous %}<a href="?search={{ search_text|urlencode:'' }}&order_by={{ order_by }}&page={{ search_results.previous_page_number }}">previous</a>{% endif %}{% if search_results.has_previous and search_results.has_next %} | {% endif %}{% if search_results.has_next %}<a href="?search={{ search_text|urlencode:'' }}&order_by={{ order_by }}&page={{ search_results.next_page_number }}">next</a>{% endif %}</p>
         {% endif %}
         </div>
         <div class="section-body">
@@ -33,6 +33,11 @@
             {% else %}
             <p class="meta">Search through tunes, settings of those tunes, or their notes or comments.<br>Some examples: {% for example in search_examples %}<a href="{% url 'tunes' %}?search={{ example }}">{{ example }}</a>{% if not forloop.last %}, {% else %}.{% endif %}{% endfor %}</p>
             <p class="meta">Currently showing all tunes.</p>
+            {% endif %}
+            {% if order_by == 'popularity' %}
+            <p class="meta">Most popular first. <a href="?search={{ search_text|urlencode:'' }}&order_by=added&page={{ search_results.number }}">Change to most recent first</a>.</p>
+            {% else %}
+            <p class="meta">Most recent first. <a href="?search={{ search_text|urlencode:'' }}&order_by=popularity&page={{ search_results.number }}">Change to most popular first</a>.</p>
             {% endif %}
             <p>&nbsp;</p>
             {% include 'archiver/_tunepreviews.html' with tunes=search_results id_prefix='search' empty_message='No matches found' %}


### PR DESCRIPTION
- `/tunes` URL has a `order_by` GET parameter
  - `added` orders by most recently added first (default)
  - `popularity` orders by salience, using same metric as homepage
- `/tunes` template has `order_by` prose and updated URLs