### PR TITLE
Feature: composer models have defaults for meter, mode and tempo

### DIFF
--- a/folk_rnn_site/composer/rnn_models.py
+++ b/folk_rnn_site/composer/rnn_models.py
@@ -45,6 +45,9 @@ def models():
             model['header_k_tokens'] = sorted(
                     {header_k_regex.search(x).group(0) for x in model['tokens'] if header_k_regex.search(x)}
                                             ) + ['*']
+            model['default_meter'] = job_spec['default_meter']
+            model['default_mode'] = job_spec['default_mode']
+            model['default_tempo'] = job_spec['default_tempo']
             models[filename] = model
         except:
             logger.warning(f'Error parsing {filename}')

--- a/folk_rnn_site/composer/static/folk_rnn_client.js
+++ b/folk_rnn_site/composer/static/folk_rnn_client.js
@@ -12,7 +12,7 @@ folkrnn.initialise = function() {
     folkrnn.fieldKey = document.getElementById("id_key");
     folkrnn.fieldMeter = document.getElementById("id_meter");
     folkrnn.fieldStartABC = document.getElementById("id_start_abc");
-    folkrnn.seedAutoButton = document.getElementById("seed_auto")
+    folkrnn.seedAutoButton = document.getElementById("seed_auto");
     folkrnn.composeButton = document.getElementById("compose_button");
     
     folkrnn.div_tune = document.getElementById("tune");
@@ -87,7 +87,7 @@ folkrnn.stateManager = {
         
         // Reveal about div, if there are no tunes
         if (Object.keys(folkrnn.tuneManager.tunes).length === 0) {
-            folkrnn.showAboutSection(true)
+            folkrnn.showAboutSection(true);
         }
     },
     'updateState': function(newState) {
@@ -191,6 +191,7 @@ folkrnn.tuneManager = {
         return folkrnn.tuneManager.tunes[tune_id].div;
     },
     '_enableABCJS_colorRange': function(range, color) {
+        "use strict";
         if (range && range.elements) {
             range.elements.forEach(function (set) {
                 set.forEach(function (item) {
@@ -200,6 +201,7 @@ folkrnn.tuneManager = {
         }
     },
     '_enableABCJS_animateCallback': function(lastRange, currentRange, context) {
+        "use strict";
         folkrnn.tuneManager._enableABCJS_colorRange(lastRange, "#000000");
         folkrnn.tuneManager._enableABCJS_colorRange(currentRange, "#3D9AFC");
     },
@@ -226,7 +228,7 @@ folkrnn.tuneManager = {
         });
         
         document.getElementById('tempo_input-' + tune_id).addEventListener("change", function (event) {
-            folkrnn.tuneManager.tunes[tune_id].abcjs.paramChanged({"qpm": parseInt(event.target.value)})
+            folkrnn.tuneManager.tunes[tune_id].abcjs.paramChanged({"qpm": parseInt(event.target.value)});
             folkrnn.websocketSend({
                 command: "notification",
                 type: "tempo",
@@ -298,7 +300,7 @@ folkrnn.generateRequest = function () {
     }
     
     if (folkrnn.fieldSeed.dataset.autoseed) {
-        folkrnn.fieldSeed.value = Math.floor(Math.random() * Math.floor(folkrnn.maxSeed))
+        folkrnn.fieldSeed.value = Math.floor(Math.random() * Math.floor(folkrnn.maxSeed));
     }
 };
 
@@ -407,7 +409,7 @@ folkrnn.updateTuneDiv = function(tune) {
         
         if (folkrnn.setComposeParametersFromTune) {
             folkrnn.utilities.setSelectByValue(folkrnn.fieldModel, tune.rnn_model_name, '');
-            folkrnn.updateKeyMeter()
+            folkrnn.updateKeyMeter();
             folkrnn.fieldTemp.value = tune.temp;
             folkrnn.fieldSeed.value = tune.seed;
             folkrnn.utilities.setSelectByValue(folkrnn.fieldKey, tune.key);
@@ -428,6 +430,7 @@ folkrnn.updateTuneDiv = function(tune) {
 };
 
 folkrnn.showAboutSection = function(toShow) {
+    "use strict";
     const div_about = document.getElementById("header");
     if (toShow) {
         div_about.removeAttribute('hidden');
@@ -442,6 +445,7 @@ folkrnn.showAboutSection = function(toShow) {
 };
 
 folkrnn.handleSeedAuto = function(autoSeedOn) {
+    "use strict";
     const seed_field_div = document.getElementById('seed_field_div');
     if (autoSeedOn) {
         seed_field_div.className = 'pure-u-1';

--- a/folk_rnn_site/composer/static/folk_rnn_client.js
+++ b/folk_rnn_site/composer/static/folk_rnn_client.js
@@ -385,6 +385,7 @@ folkrnn.updateTuneDiv = function(tune) {
     const el_requested = document.getElementById("requested-" + tune.id);
     const el_generated = document.getElementById("generated-" + tune.id);
     const el_tempo = document.getElementById("tempo-" + tune.id);
+    const el_tempo_input = document.getElementById('tempo_input-' + tune.id)
     const el_archive_form = document.getElementById("archive_form-" + tune.id);
     const el_archive_title = document.getElementById("id_title-" + tune.id);
     
@@ -396,6 +397,7 @@ folkrnn.updateTuneDiv = function(tune) {
     el_prime_tokens.textContent = tune.prime_tokens;
     el_requested.textContent = tune.requested;
     el_generated.textContent = tune.rnn_finished;
+    el_tempo_input.value = folkrnn.models[tune.rnn_model_name].default_tempo;
     if (tune.rnn_finished) {
         el_generated.textContent = new Date(tune.rnn_finished).toLocaleString();
         el_requested.parentNode.setAttribute('hidden', '');

--- a/folk_rnn_site/composer/static/folk_rnn_client.js
+++ b/folk_rnn_site/composer/static/folk_rnn_client.js
@@ -337,6 +337,8 @@ folkrnn.updateKeyMeter = function() {
     // Keep selected value if possible
     const meter = folkrnn.fieldMeter.value;
     const key = folkrnn.fieldKey.value;
+    const fallback_meter = 'M:' + folkrnn.models[folkrnn.fieldModel.value].default_meter
+    const fallback_key = 'K:' + folkrnn.models[folkrnn.fieldModel.value].default_mode
 
     // Set Meter options from model
     while (folkrnn.fieldMeter.lastChild) {
@@ -346,7 +348,7 @@ folkrnn.updateKeyMeter = function() {
         const label = (m === '*') ? '?/?' : m.slice(2)
         folkrnn.fieldMeter.appendChild(new Option(label, m));
     }
-    folkrnn.utilities.setSelectByValue(folkrnn.fieldMeter, meter, 'M:4/4');
+    folkrnn.utilities.setSelectByValue(folkrnn.fieldMeter, meter, fallback_meter);
 
     // Set Key options from model
     while (folkrnn.fieldKey.lastChild) {
@@ -363,7 +365,7 @@ folkrnn.updateKeyMeter = function() {
         const label = (k === '*') ? '? ???' : k.slice(2,-3) + " " + key_map[k.slice(-3).toLowerCase()]
         folkrnn.fieldKey.appendChild(new Option(label, k));
     }
-    folkrnn.utilities.setSelectByValue(folkrnn.fieldKey, key, 'K:Cmaj');
+    folkrnn.utilities.setSelectByValue(folkrnn.fieldKey, key, fallback_key);
 };
 
 folkrnn.updateTuneDiv = function(tune) {

--- a/folk_rnn_site/composer/static/folk_rnn_model_utilities.js
+++ b/folk_rnn_site/composer/static/folk_rnn_model_utilities.js
@@ -133,7 +133,7 @@ folkrnn.parseABC = function(abc) {
             flag_innote=0;
             flag_indur=0;
             flag_expectingnote=0;
-            result.push(c)
+            result.push(c);
         } else {
             invalidIndexes.push(i);
         }

--- a/folk_rnn_site/composer/views.py
+++ b/folk_rnn_site/composer/views.py
@@ -10,6 +10,7 @@ from tempfile import TemporaryFile
 
 from folk_rnn_site.models import conform_abc
 from composer.models import RNNTune
+from composer.rnn_models import models
 from composer.forms import ComposeForm, ArchiveForm
 from composer.dataset import dataset_as_csv
 from archiver.models import Tune
@@ -56,6 +57,7 @@ def archive_tune(request, tune_id=None):
                     is_valid = False
                 tune_in_archive = Tune(rnn_tune=tune, abc=tune.abc, check_valid_abc=is_valid)
                 tune_in_archive.title = form.cleaned_data['title']
+                tune_in_archive.header_q = models()[tune.rnn_model_name]['default_tempo']
                 tune_in_archive.save()
             return redirect(reverse('tune', host='archiver', kwargs={'tune_id': tune_in_archive.id}))
     return redirect('/')

--- a/folk_rnn_site/folk_rnn_site/models.py
+++ b/folk_rnn_site/folk_rnn_site/models.py
@@ -163,6 +163,14 @@ class ABCModel(models.Model):
         match = header_q_regex.search(self.abc)
         return match.group(1) if match else None
     
+    @header_q.setter
+    def header_q(self, value):
+        if header_q_regex.search(self.abc):
+            sub = f'Q:{value}\n' if value else ''
+            self.abc = header_q_regex.sub(sub, self.abc, count=1)
+        elif value:
+            self.abc = header_k_regex.sub(f'Q:{value}\nK:{self.header_k}\n', self.abc)
+    
     @property
     def header_m(self):
         '''

--- a/folk_rnn_site/folk_rnn_site/tests.py
+++ b/folk_rnn_site/folk_rnn_site/tests.py
@@ -145,6 +145,26 @@ N:Note 3
 M:4/4
 K:Cmaj
 {ABC_BODY}''')
+    
+    def test_q_property(self):
+        tune = ConcreteABCTune(abc=mint_abc())
+        self.assertEqual(tune.header_q, None)
+        tune.header_q = 120
+        self.assertEqual(tune.header_q, '120')
+        self.assertEqual(tune.abc, f'''X:0
+T:{ABC_TITLE}
+M:4/4
+Q:120
+K:Cmaj
+{ABC_BODY}''')
+        tune.header_q = 105
+        self.assertEqual(tune.header_q, '105')
+        self.assertEqual(tune.abc, f'''X:0
+T:{ABC_TITLE}
+M:4/4
+Q:105
+K:Cmaj
+{ABC_BODY}''')
             
     def test_body_property(self):
         tune = ConcreteABCTune(abc=mint_abc())

--- a/tools/create_model_from_config_meta.py
+++ b/tools/create_model_from_config_meta.py
@@ -7,9 +7,11 @@ import importlib
 import pickle
 
 metadata_paths = [
-        ('/folk_rnn/metadata/config5-wrepeats-20160112-222521.pkl', 'thesession_with_repeats', 'thesession.org (w/ :| |:)'),
-        ('/folk_rnn/metadata/config5-worepeats-20160311-134539.pkl', 'thesession_without_repeats', 'thesession.org (w/o :| |:)'),
-        ('/folk_rnn/metadata/lstm_dropout-9_nov_folkwiki-20181112-195023_epoch89.pkl', 'swedish', 'folkwiki.se'),
+        # Tuple format: metadata_pickle_path, new_filename, display_name, default_meter, default_mode, default_tempo
+        # Note: default_mode capitalisation as per model token!
+        ('/folk_rnn/metadata/config5-wrepeats-20160112-222521.pkl', 'thesession_with_repeats', 'thesession.org (w/ :| |:)', '4/4', 'Cmaj', 120),
+        ('/folk_rnn/metadata/config5-worepeats-20160311-134539.pkl', 'thesession_without_repeats', 'thesession.org (w/o :| |:)', '4/4', 'Cmaj', 120),
+        ('/folk_rnn/metadata/lstm_dropout-9_nov_folkwiki-20181112-195023_epoch89.pkl', 'swedish', 'folkwiki.se', '3/4', 'DMin', 105),
         # ('/folk_rnn/metadata/config5_resume-allabcworepeats_parsed_Tallis_trimmed1000-20171228-191847_epoch39.pkl', 'without_repeats_tallis'),
         ]
 
@@ -22,7 +24,7 @@ try:
 except:
     pass
 
-for idx, (metadata_path, model_filename, model_displayname) in enumerate(metadata_paths): 
+for idx, (metadata_path, model_filename, model_displayname, default_meter, default_mode, default_tempo) in enumerate(metadata_paths): 
     with open(metadata_path, 'rb') as f:
         metadata = pickle.load(f, encoding='latin1') # latin1 maps 0-255 to unicode 0-255
         
@@ -33,6 +35,9 @@ for idx, (metadata_path, model_filename, model_displayname) in enumerate(metadat
         'param_values': metadata['param_values'], 
         'num_layers': config.num_layers, 
         'metadata_path': metadata_path,
+        'default_meter': default_meter,
+        'default_mode': default_mode, 
+        'default_tempo': default_tempo,
     }
     
     path = os.path.join(model_dir, model_filename + '.pickle')


### PR DESCRIPTION
- Supply default meter, mode and tempo values alongside display name etc. in `tools/create_model_from_config_meta.py`
- Changing model generate parameter has better behaviour
  - Changing to a model with different options sets default option for that model
  - Possibly chased down a bug when state is applied of a different model
- Composer tempo control set to the default temp
- Archived tunes have Q: set to the default tempo