### PR TITLE
Tweak: Initial ABC header parsing

### DIFF
--- a/folk_rnn_site/composer/static/folk_rnn_model_utilities.js
+++ b/folk_rnn_site/composer/static/folk_rnn_model_utilities.js
@@ -37,23 +37,32 @@ folkrnn.parseABC = function(abc) {
     
     let header = {};
     let body_start_index = 0;
-    
-    let header_regex = /\[?(L:\d+\/\d+)]?\n\[?(M:\d+\/\d+)\]?\n\[?(K:[A-G][b#]?[A-Za-z]{3})\]?\n?/g;
-    let match = header_regex.exec(abc);
-    if (match !== null) {
-        header.l = match[1];
-        header.m = match[2];
-        header.k = match[3];
-        body_start_index = header_regex.lastIndex
-    } else {
+    parse_header: {
+        let header_regex = /\[?(L:\d+\/\d+)]?\n\[?(M:\d+\/\d+)\]?\n\[?(K:[A-G][b#]?[A-Za-z]{3})\]?\n?/g;
+        let match = header_regex.exec(abc);
+        if (match !== null) {
+            header.l = match[1];
+            header.m = match[2];
+            header.k = match[3];
+            body_start_index = header_regex.lastIndex
+            break parse_header;
+        } 
         header_regex = /\[?(M:\d+\/\d+)\]?\n\[?(K:[A-G][b#]?[A-Za-z]{3})\]?\n?/g;
         match = header_regex.exec(abc);
         if (match !== null) {
            header.m = match[1];
            header.k = match[2];
            body_start_index = header_regex.lastIndex
-        }   
-    } 
+           break parse_header;
+        }
+        header_regex = /\[?(L:\d+\/\d+)]?\n?/g;
+        match = header_regex.exec(abc);
+        if (match !== null) {
+           header.l = match[1];
+           body_start_index = header_regex.lastIndex
+           break parse_header;
+        }
+    }
     
     // BODY
     

--- a/folk_rnn_site/composer/static/folk_rnn_model_utilities.js
+++ b/folk_rnn_site/composer/static/folk_rnn_model_utilities.js
@@ -38,7 +38,7 @@ folkrnn.parseABC = function(abc) {
     let header = {};
     let body_start_index = 0;
     
-    let header_regex = /\[?(L:\d+\/\d+)]?\n\[?(M:\d+\/\d+)\]?\n\[?(K:[A-G][b#]?[A-Za-z]{3})\]?\n/g;
+    let header_regex = /\[?(L:\d+\/\d+)]?\n\[?(M:\d+\/\d+)\]?\n\[?(K:[A-G][b#]?[A-Za-z]{3})\]?\n?/g;
     let match = header_regex.exec(abc);
     if (match !== null) {
         header.l = match[1];
@@ -46,7 +46,7 @@ folkrnn.parseABC = function(abc) {
         header.k = match[3];
         body_start_index = header_regex.lastIndex
     } else {
-        header_regex = /\[?(M:\d+\/\d+)\]?\n\[?(K:[A-G][b#]?[A-Za-z]{3})\]?\n/g;
+        header_regex = /\[?(M:\d+\/\d+)\]?\n\[?(K:[A-G][b#]?[A-Za-z]{3})\]?\n?/g;
         match = header_regex.exec(abc);
         if (match !== null) {
            header.m = match[1];


### PR DESCRIPTION
- Headers no longer require a trailing new line to be detected (e.g. can have no body following)
- A single `L` header will be parsed