### PR TITLE
Fix: ABC attribution

### DIFF
--- a/folk_rnn_site/archiver/models.py
+++ b/folk_rnn_site/archiver/models.py
@@ -120,7 +120,7 @@ class Tune(ABCModel):
         abc_model.headers_n = ['{} {}'.format(x.text if x.text else '', x.url if x.url else '') for x in self.tuneattribution_set.all()]
         if self.rnn_tune:
             model = self.rnn_tune.rnn_model_name.replace('.pickle', '')
-            abc_model.headers_n += [ f'Generated at https://folkrnn.org using the { model } model with RNN seed = { self.rnn_tune.seed }; temperature = { self.rnn_tune.temp }; prime tokens = { self.rnn_tune.prime_tokens }' ]
+            abc_model.headers_n += [ f"Generated at https://{ reverse_host('composer') } using the { model } model with RNN seed = { self.rnn_tune.seed }; temperature = { self.rnn_tune.temp }; prime tokens = { self.rnn_tune.prime_tokens }" ]
         abc_model.header_f = url
         abc_model.header_s = f'Tune #{self.id} archived at The Machine Folk Session'
         return abc_model.abc

--- a/folk_rnn_site/archiver/models.py
+++ b/folk_rnn_site/archiver/models.py
@@ -7,6 +7,7 @@ from django.utils.timezone import now
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.core.exceptions import ValidationError
 from django.urls import reverse
+from django_hosts import reverse_host
 from embed_video.fields import EmbedVideoField
 from random import shuffle
 from datetime import timedelta
@@ -114,7 +115,7 @@ class Tune(ABCModel):
         """"
         Return abc with attribution information fields
         """
-        url = self.get_absolute_url()
+        url = f"https://{ reverse_host('archiver') }{ self.get_absolute_url() }"
         abc_model = ABCModel(abc=self.abc)
         abc_model.headers_n = ['{} {}'.format(x.text if x.text else '', x.url if x.url else '') for x in self.tuneattribution_set.all()]
         if self.rnn_tune:
@@ -257,7 +258,7 @@ class Setting(ABCModel):
         """
         Return abc with attribution information fields
         """
-        url = self.get_absolute_url()
+        url = f"https://{ reverse_host('archiver') }{ self.get_absolute_url() }"
         abc_model = ABCModel(abc=self.abc)
         if self.tune.rnn_tune:
             model = self.tune.rnn_tune.rnn_model_name.replace('.pickle', '')

--- a/folk_rnn_site/archiver/tests.py
+++ b/folk_rnn_site/archiver/tests.py
@@ -115,7 +115,7 @@ class TunePageTest(ArchiverTestCase):
         self.assertContains(response, comment_html, html=True)
 
 @skip('TODO. Existing tests are as per v1 functionality, many further tests still needed...')
-class UserActionsTest(ArchiverTestCase):
+class UserActionsTest___v1(ArchiverTestCase):
     
     def test_tune_page_can_save_a_setting_POST_request(self):
         pass
@@ -142,6 +142,21 @@ class UserActionsTest(ArchiverTestCase):
         self.assertEqual(comment.text, 'My first comment.')
         self.assertEqual(comment.author, 'A. Person')
         self.assertAlmostEqual(comment.submitted, now(), delta=timedelta(seconds=0.1))
+
+class UserActionsTest(ArchiverTestCase):        
+
+    def test_tune_download(self):
+        tune_id = Tune.objects.last().id
+        expected = f"""X:{tune_id}
+T:Test Tune
+S:Tune #{tune_id} archived at The Machine Folk Session
+F:https://themachinefolksession.org/tune/{tune_id}
+N:Generated at https://folkrnn.org using the thesession_with_repeats model with RNN seed = 123; temperature = 0.1; prime tokens = M:4/4 K:Cmaj a b c
+M:4/4
+K:Cmaj
+A B C"""
+        response = self.client.get(f'/tune/{tune_id}/download')
+        self.assertEqual(response.content, expected.encode())
 
 class DatasetTest(ArchiverTestCase):
 

--- a/folk_rnn_site/composer/models.py
+++ b/folk_rnn_site/composer/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from folk_rnn_site.models import ABCModel
-from django_hosts.resolvers import reverse
+from django.urls import reverse
 
 from composer.rnn_models import token_for_info_field
 
@@ -20,11 +20,11 @@ class RNNTune(ABCModel):
     
     @property
     def url(self):
-        return reverse('tune', host='composer', kwargs={'tune_id': self.id})
+        return reverse('tune', kwargs={'tune_id': self.id})
 
     @property
     def archive_url(self):
-        return reverse('archive_tune', host='composer', kwargs={'tune_id': self.id})
+        return reverse('archive_tune', kwargs={'tune_id': self.id})
     
     def plain_dict(self):
         return {


### PR DESCRIPTION
URLs in ABC downloaded from themachinefolksession.org are once more fully qualified.

Broke in 313915dbaf8ceba803cc75cbaa25e5b4fac0918b
This PR fixes, adds test, plus minor clean-up.